### PR TITLE
[TEMP] Updater: remove check for current version

### DIFF
--- a/src/com/crdroid/updater/misc/Utils.java
+++ b/src/com/crdroid/updater/misc/Utils.java
@@ -115,10 +115,10 @@ public class Utils {
     }
 
     public static boolean isCompatible(UpdateBaseInfo update) {
-        if (update.getVersion().compareTo(SystemProperties.get(Constants.PROP_BUILD_VERSION)) < 0) {
-            Log.d(TAG, update.getName() + " is older than current Android version");
-            return false;
-        }
+        //if (update.getVersion().compareTo(SystemProperties.get(Constants.PROP_BUILD_VERSION)) < 0) {
+        //    Log.d(TAG, update.getName() + " is older than current Android version");
+        //    return false;
+        //}
         if (!SystemProperties.getBoolean(Constants.PROP_UPDATER_ALLOW_DOWNGRADING, false) &&
                 update.getTimestamp() <= SystemProperties.getLong(Constants.PROP_BUILD_DATE, 0)) {
             Log.d(TAG, update.getName() + " is older than/equal to the current build");


### PR DESCRIPTION
current crDroid version being 6.10 (seen as 6.1) is lower value then old 6.9 and no update is provided to end user
remove the check for this and rely on timestamp comparison only for now