### PR TITLE
Updater: Add POST_NOTIFICATIONS permission & pre-grant it

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -41,15 +41,24 @@ android_app {
         proguard_flags_files: ["proguard.flags"],
     },
 
-    required: ["privapp_whitelist_com.crdroid.updater.xml"],
-
+    required: [
+        "privapp_whitelist_com.crdroid.updater",
+        "default-permissions_com.crdroid.updater"
+    ],
 }
 
 prebuilt_etc {
-    name: "privapp_whitelist_com.crdroid.updater.xml",
-
+    name: "privapp_whitelist_com.crdroid.updater",
     system_ext_specific: true,
-    src: "privapp_whitelist_com.crdroid.updater.xml",
     sub_dir: "permissions",
+    src: "privapp_whitelist_com.crdroid.updater.xml",
+    filename_from_src: true,
+}
 
+prebuilt_etc {
+    name: "default-permissions_com.crdroid.updater",
+    system_ext_specific: true,
+    sub_dir: "default-permissions",
+    src: "default-permissions_com.crdroid.updater.xml",
+    filename_from_src: true,
 }

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REBOOT" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.RECOVERY" />

--- a/default-permissions_com.crdroid.updater.xml
+++ b/default-permissions_com.crdroid.updater.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<!--
+     Copyright (C) 2022 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<exceptions>
+    <exception package="com.crdroid.updater">
+        <!-- Notifications -->
+        <permission name="android.permission.POST_NOTIFICATIONS" fixed="false"/>
+    </exception>
+</exceptions>


### PR DESCRIPTION
Taken from +2 voted patchset on lineage gerrit that hasn't been merged yet.

Tested on enchilada & fajita (oneplus 6 & 6T), seems to work as advertised. After flashing updated build from recovery, attempting to do local update with same build copied to internal storage now shows notification again, which remains visible with functional "Reboot" button at the bottom once installation has completed successfully, even after primary Updater app activity resets itself.

Figured I'd save you some time reconciling crDroid changes to Lineage base.

Now if we knew how to keep Updater activity view from resetting itself after installation completes, that would be awesome... :D
_____

Without the permission, Updater can't spawn notifications on downloads/install

Reference: https://developer.android.com/develop/ui/views/notifications/notification-permission Test: boot, download an update via updater, check notification drawer
Co-authored-by: Michael Bestas <mkbestas@lineageos.org>
Change-Id: I131c62ae5033f56f8915426f68f7aea76dba78dd

[crDroid]
Modified to account for changes from https://github.com/crdroidandroid/android_packages_apps_Updater/commit/3d89017be59d0f21879a5e50a069139e2c5faf26